### PR TITLE
CI: Pubilsh CRD to dist branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,6 +1,6 @@
 name: Go
 
-on: [pull_request]
+on: [pull_request, push]
 
 
 jobs:
@@ -15,5 +15,27 @@ jobs:
         with:
           go-version: 1.17
 
+      - name: Remove old artifacts
+        run: rm -rf artifacts/deploy
+
       - name: Build
         run: make all
+
+      - name: Concat artifacts yaml
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          echo ${GITHUB_REF##*/}
+          for i in artifacts/deploy/*; do cat $i >> artifacts/deploy/all.yaml; done;
+      
+      - id: git-branch
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          echo "::set-output name=git-branch::$(echo ${GITHUB_REF##*/} | tr '[A-Z]' '[a-z]')"
+
+      - name: Publish to Dist Branch
+        if: ${{ github.event_name == 'push' }}
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: dist
+          folder: artifacts/deploy
+          target-folder: ${{steps.git-branch.outputs.git-branch}}

--- a/README.md
+++ b/README.md
@@ -18,3 +18,15 @@ make verify
 kubectl create -f artifacts/deploy/
 
 ```
+
+# INSTALL CRD ONLINE
+
+You can find other versions base on the branch or tags in dist branch.
+
+[Click here to view the early version.](https://fastly.jsdelivr.net/gh/gocrane/api@dist/)
+
+```bash
+
+kubectl create -f https://raw.githubusercontent.com/gocrane/api/dist/main/all.yaml
+
+```


### PR DESCRIPTION
Easy for us to use the CRD and archive each version.

Example:

https://github.com/zsnmwy/api/tree/dist
https://fastly.jsdelivr.net/gh/zsnmwy/api@dist/