### PR TITLE
chore: move recommend struct from kubectl-crane to api

### DIFF
--- a/analysis/v1alpha1/types.go
+++ b/analysis/v1alpha1/types.go
@@ -381,3 +381,29 @@ type ContainerRecommendation struct {
 }
 
 type ResourceList map[corev1.ResourceName]string
+
+type PatchReplicas struct {
+	Spec PatchReplicasSpec `json:"spec,omitempty"`
+}
+
+type PatchReplicasSpec struct {
+	Replicas *int32 `json:"replicas,omitempty"`
+}
+
+type PatchResource struct {
+	Spec PatchResourceSpec `json:"spec,omitempty"`
+}
+
+type PatchResourceSpec struct {
+	Template PatchResourcePodTemplateSpec `json:"template"`
+}
+
+type PatchResourcePodTemplateSpec struct {
+	Spec PatchResourcePodSpec `json:"spec,omitempty"`
+}
+
+type PatchResourcePodSpec struct {
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	Containers []corev1.Container `json:"containers" patchStrategy:"merge" patchMergeKey:"name"`
+}

--- a/analysis/v1alpha1/types.go
+++ b/analysis/v1alpha1/types.go
@@ -313,14 +313,9 @@ type RecommendationRuleSpec struct {
 
 // Recommender referring to the Recommender in RecommendationConfiguration
 type Recommender struct {
-	// ResourceSelector indicates which resources(e.g. a set of Deployments) are accepted for plugin.
-	// Override the accepted resources from recommender's interface
-	AcceptedResourceSelectors []ResourceSelector `json:"acceptedResources"`
-	// Name should be existed in all predefined recommenders
+
+	// Recommender's Name
 	Name string `json:"name"`
-	// Override Recommender configs
-	// +optional
-	Config map[string]string `json:"config,omitempty"`
 }
 
 // NamespaceSelector describes how to select namespaces for recommend

--- a/analysis/v1alpha1/types.go
+++ b/analysis/v1alpha1/types.go
@@ -1,10 +1,11 @@
 package v1alpha1
 
 import (
-	autoscalingapi "github.com/gocrane/api/autoscaling/v1alpha1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	autoscalingapi "github.com/gocrane/api/autoscaling/v1alpha1"
 )
 
 type AnalysisType string
@@ -27,6 +28,20 @@ const (
 	AdoptionTypeStatus              AdoptionType = "Status"
 	AdoptionTypeStatusAndAnnotation AdoptionType = "StatusAndAnnotation"
 	AdoptionTypeAuto                AdoptionType = "Auto"
+)
+
+const (
+	// ReplicasRecommender name
+	ReplicasRecommender string = "Replicas"
+
+	// ResourceRecommender name
+	ResourceRecommender string = "Resource"
+
+	// HPARecommender name
+	HPARecommender string = "HPA"
+
+	// IdleNodeRecommender name
+	IdleNodeRecommender string = "IdleNode"
 )
 
 // +genclient

--- a/analysis/v1alpha1/types.go
+++ b/analysis/v1alpha1/types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	autoscalingapi "github.com/gocrane/api/autoscaling/v1alpha1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -345,3 +347,37 @@ type RecommendationRuleList struct {
 
 	Items []RecommendationRule `json:"items"`
 }
+
+// ProposedRecommendation is the result for one recommendation
+type ProposedRecommendation struct {
+	// EffectiveHPA is the proposed recommendation for type Replicas
+	EffectiveHPA *EffectiveHorizontalPodAutoscalerRecommendation `json:"effectiveHPA,omitempty"`
+
+	// ReplicasRecommendation is the proposed replicas for type Replicas
+	ReplicasRecommendation *ReplicasRecommendation `json:"replicasRecommendation,omitempty"`
+
+	// ResourceRequest is the proposed recommendation for type Resource
+	ResourceRequest *ResourceRequestRecommendation `json:"resourceRequest,omitempty"`
+}
+
+type ReplicasRecommendation struct {
+	Replicas *int32 `json:"replicas,omitempty"`
+}
+
+type EffectiveHorizontalPodAutoscalerRecommendation struct {
+	MinReplicas *int32                     `json:"minReplicas,omitempty"`
+	MaxReplicas *int32                     `json:"maxReplicas,omitempty"`
+	Metrics     []autoscalingv2.MetricSpec `json:"metrics,omitempty"`
+	Prediction  *autoscalingapi.Prediction `json:"prediction,omitempty"`
+}
+
+type ResourceRequestRecommendation struct {
+	Containers []ContainerRecommendation `json:"containers,omitempty"`
+}
+
+type ContainerRecommendation struct {
+	ContainerName string       `json:"containerName,omitempty"`
+	Target        ResourceList `json:"target,omitempty"`
+}
+
+type ResourceList map[corev1.ResourceName]string

--- a/analysis/v1alpha1/types.go
+++ b/analysis/v1alpha1/types.go
@@ -313,9 +313,14 @@ type RecommendationRuleSpec struct {
 
 // Recommender referring to the Recommender in RecommendationConfiguration
 type Recommender struct {
-
-	// Recommender's Name
+	// ResourceSelector indicates which resources(e.g. a set of Deployments) are accepted for plugin.
+	// Override the accepted resources from recommender's interface
+	AcceptedResourceSelectors []ResourceSelector `json:"acceptedResources"`
+	// Name should be existed in all predefined recommenders
 	Name string `json:"name"`
+	// Override Recommender configs
+	// +optional
+	Config map[string]string `json:"config,omitempty"`
 }
 
 // NamespaceSelector describes how to select namespaces for recommend


### PR DESCRIPTION
move related recommend struct which located kubectl-crane to api